### PR TITLE
Fix missing argument in check_errors

### DIFF
--- a/latexmake.py
+++ b/latexmake.py
@@ -225,7 +225,7 @@ class LatexMaker (object):
             name, ext_i, ext_o = match.groups()
             self.glossaries[name] = (ext_i, ext_o)
 
-    def check_errors(self):
+    def check_errors(self, cmd):
         '''
         Check if errors occured during a latex run by
         scanning the output.
@@ -319,7 +319,7 @@ class LatexMaker (object):
 
         self.latex_run_counter += 1
 
-        return self.check_errors()
+        return self.check_errors(cmd)
 
     def bibtex_run(self):
         '''


### PR DESCRIPTION
There was a small error in the check_errors method. In case of an error it uses `cmd` which was not available. This commit just adds a `cmd` argument and hands it over in the call.